### PR TITLE
Remove the redundant Lombok dependency as Lombok dependency included in the lombok plugin of freefair

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ repositories {
 
 dependencies {
     compile group: 'org.aspectj', name: 'aspectjrt', version: '1.9.4'
-    compile group: 'org.projectlombok', name: 'lombok', version: '1.18.10'
     testCompile group: 'org.testng', name: 'testng', version: '6.14.3'
 }
 


### PR DESCRIPTION
Remove the redundant Lombok dependency as Lombok dependency included in the lombok plugin of freefair

issue: #4